### PR TITLE
Changed the order of arguments given to callbacks so that error comes first

### DIFF
--- a/example.js
+++ b/example.js
@@ -8,7 +8,7 @@ function microtime(get_as_float) {
 }
 
 var onConnect = function() {
-	mcClient.get('test', function(data) {
+	mcClient.get('test', function(err, data) {
 		sys.debug(data);
 		mcClient.close();
 	});
@@ -20,8 +20,8 @@ var benchmark = function() {
 	var x = 0;
 	
 	for (var i=0; i<=count; i++) {
-		mcClient.get('test', function(data) {
-			x += 1;		
+		mcClient.get('test', function(err, data) {
+			x += 1;
 			if (x == count) {
 				end = microtime(true);
 				sys.debug('total time: ' + (end - start));
@@ -33,8 +33,8 @@ var benchmark = function() {
 };
 
 var setKey = function() {
-	mcClient.set('test', 'hello \r\n node-memcache', function(response) {
-		mcClient.get('test', function(data) {
+	mcClient.set('test', 'hello \r\n node-memcache', function(err, response) {
+		mcClient.get('test', function(err, data) {
 			sys.debug(data);
 			mcClient.close();
 		});
@@ -42,21 +42,21 @@ var setKey = function() {
 };
 
 var version = function() {
-	mcClient.version(function(version) {
+	mcClient.version(function(err, version) {
 		sys.debug(version);
 		mcClient.close();
 	});
 };
 
 var incr = function() {
-	mcClient.increment('x', 2, function(new_value) {
+	mcClient.increment('x', 2, function(err, new_value) {
 		sys.debug(new_value);
 		mcClient.close();
 	});
 };
 
 var decr = function() {
-	mcClient.decrement('x', 1, function(new_value) {
+	mcClient.decrement('x', 1, function(err, new_value) {
 		sys.debug(new_value);
 		mcClient.close();
 	});

--- a/lib/memcache.js
+++ b/lib/memcache.js
@@ -235,7 +235,7 @@ Client.prototype.handle_received_data = function(){
 		var callback = this.callbacks.shift();
 		if (callback != null && callback.fun){
 			this.replies++;
-			callback.fun(result_value, result_error);
+			callback.fun(result_error, result_value);
 		}
 	}
 };

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "git://github.com/elbart/node-memcache.git",
   "author": "Tim Eggert <tim@elbart.com>",
   "main": "./lib/memcache",
-  "dependencies": {
+  "devDependencies": {
     "expresso": ">=0.7.0"
   },
   "directories": {

--- a/test/test-memcache.js
+++ b/test/test-memcache.js
@@ -29,7 +29,7 @@ mc.addHandler(function() {
 	// test nonexistent key is null
 	exports['test null value'] = function(beforeExit) {
 		var n = 0;
-		mc.get('no such key', function(r) {
+		mc.get('no such key', function(err, r) {
 			assert.equal(null, r);
 			n++;
 		});
@@ -45,7 +45,7 @@ mc.addHandler(function() {
 		// set key
 		mc.set('set1', 'asdf1', function() {
 			n++;
-			mc.get('set1', function(r) {
+			mc.get('set1', function(err, r) {
 				// assert key is found
 				assert.equal('asdf1', r);
 				n++;
@@ -67,7 +67,7 @@ mc.addHandler(function() {
 
     exports['test set get with integer value'] = function(beforeExit) {
         mc.set('testKey', 123, function() {
-            mc.get('testKey', function(r) {
+            mc.get('testKey', function(err, r) {
                 assert.equal(123,r);
             });
         });
@@ -79,13 +79,13 @@ mc.addHandler(function() {
 		// set key
 		mc.set('set2', 'asdf2', function() {
 			n++;
-			mc.get('set2', function(r) {
+			mc.get('set2', function(err, r) {
 				// assert key is found
 				assert.equal('asdf2', r);
 				n++;
 				// delete key
 				mc.delete('set2', function() {
-					mc.get('set2', function(r) {
+					mc.get('set2', function(err, r) {
 						// assert key is null
 						assert.equal(null, r);
 						n++;
@@ -102,7 +102,7 @@ mc.addHandler(function() {
     // test utf8 handling
     exports['utf8'] = function(beforeExit) {
         mc.set('key1', 'привет', function() {
-            mc.get('key1', function(r) {
+            mc.get('key1', function(err, r) {
                 assert.equal('привет', r);
             });
         });
@@ -135,44 +135,44 @@ mc.addHandler(function() {
 
 		var n = 0;
 
-		mc.set('inc_bad', 'HELLO', function(response){
+		mc.set('inc_bad', 'HELLO', function(err, response){
 			assert.equal(response, 'STORED');
 			n++;
-			mc.increment('inc_bad', 2, function(ok, err){
+			mc.increment('inc_bad', 2, function(err, ok){
 				n++;
-				assert.equal(ok, null);
 				assert.match(err, /^CLIENT_ERROR/);
+				assert.equal(ok, null);
 			});
-			mc.decrement('inc_bad', 3, function(ok, err){
+			mc.decrement('inc_bad', 3, function(err, ok){
 				n++;
-				assert.equal(ok, null);
 				assert.match(err, /^CLIENT_ERROR/);
+				assert.equal(ok, null);
 			});
-			mc.increment('inc_bad', null, function(ok, err){
+			mc.increment('inc_bad', null, function(err, ok){
 				n++;
-				assert.equal(ok, null);
 				assert.match(err, /^CLIENT_ERROR/);
+				assert.equal(ok, null);
 			});
-			mc.decrement('inc_bad', null, function(ok, err){
+			mc.decrement('inc_bad', null, function(err, ok){
 				n++;
-				assert.equal(ok, null);
 				assert.match(err, /^CLIENT_ERROR/);
+				assert.equal(ok, null);
 			});
 		});
 
-		mc.set('inc_good', '5', function(response){
+		mc.set('inc_good', '5', function(err, response){
 			assert.equal(response, 'STORED');
 			n++;
-			mc.increment('inc_good', 2, function(response){
+			mc.increment('inc_good', 2, function(err, response){
 				n++;
 				assert.equal(response, 7);
-				mc.increment('inc_good', function(response){
+				mc.increment('inc_good', function(err, response){
 					n++;
 					assert.equal(response, 8);
-					mc.decrement('inc_good', function(response){
+					mc.decrement('inc_good', function(err, response){
 						n++;
 						assert.equal(response, 7);
-						mc.decrement('inc_good', 4, function(response){
+						mc.decrement('inc_good', 4, function(err, response){
 							n++;
 							assert.equal(response, 3);
 						});
@@ -190,7 +190,7 @@ mc.addHandler(function() {
 	exports['version'] = function(beforeExit){
 		var n = 0;
 
-		mc.version(function(success, error){
+		mc.version(function(error, success){
 			n++;
 			assert.equal(error, null);
 			assert.length(success, 5);
@@ -204,21 +204,21 @@ mc.addHandler(function() {
 	exports['stats'] = function(beforeExit){
 		var n = 0;
 
-		mc.stats(function(success, error){
+		mc.stats(function(error, success){
 			n++;
 			assert.ok(success.pid, "server has a pid");
 		});
 
-		mc.stats('settings', function(success, error){
+		mc.stats('settings', function(error, success){
 			n++;
 			assert.ok(success.maxconns);
 		});
 
-		mc.stats('items', function(success, error){ n++; assert.ok(num_keys(success)); });
-		mc.stats('sizes', function(success, error){ n++; assert.ok(num_keys(success)); });
-		mc.stats('slabs', function(success, error){ n++; assert.ok(num_keys(success)); });
+		mc.stats('items', function(error, success){ n++; assert.ok(num_keys(success)); });
+		mc.stats('sizes', function(error, success){ n++; assert.ok(num_keys(success)); });
+		mc.stats('slabs', function(error, success){ n++; assert.ok(num_keys(success)); });
 
-		mc.stats('notreal', function(success, error){
+		mc.stats('notreal', function(error, success){
 			n++;
 			assert.equal(error, 'ERROR');
 		});


### PR DESCRIPTION
This is the Node convention used throughout the core modules and most of the npm libraries rely on this behavior as well (e.g. async).

I understand this is a backwards compatibility breaking change, so I would suggest to do at least a minor version bump after you apply this change. I also updated the tests (they all pass) and the README as well.

Fixes #9.
