### PR TITLE
Added support for 'stats reset' command

### DIFF
--- a/lib/memcache.js
+++ b/lib/memcache.js
@@ -295,6 +295,12 @@ Client.prototype.handle_stats = function(buffer){
 		return [{}, 5];
 	}
 
+    // special case - stats reset
+	if (buffer.indexOf('RESET') == 0){
+		return [{}, 7];
+	}
+
+
 	// find the terminator
 	var idx = buffer.indexOf('\r\nEND\r\n');
 	if (idx == -1){


### PR DESCRIPTION
It's possible to reset stats in memcache by sending 'stats reset\r\n'. This works with your client but the response wasn't being checked for and as result callbacks weren't firing afterwards. The fix is only a couple of lines. Please pull.

Cheers,
Geoff
