### PR TITLE
Fixed bug when 'END' is contained in the cached data

### DIFF
--- a/lib/memcache.js
+++ b/lib/memcache.js
@@ -271,11 +271,11 @@ Client.prototype.handle_get = function(buffer) {
     var end_indicator_len = 3;
     var result_len = 0;
     
-    if (buffer.indexOf('END') == 0) {
+    if (buffer.lastIndexOf('END') == 0) {
         return [result_value, end_indicator_len + crlf_len];
-    } else if (buffer.indexOf('VALUE') == 0 && buffer.indexOf('END') != -1) {
+    } else if (buffer.indexOf('VALUE') == 0 && buffer.lastIndexOf('END') != -1) {
         first_line_len = buffer.indexOf(crlf) + crlf_len;
-        var end_indicator_start = buffer.indexOf('END');
+        var end_indicator_start = buffer.lastIndexOf('END');
         result_len = end_indicator_start - first_line_len - crlf_len;
         result_value = buffer.substr(first_line_len, result_len);
         return [result_value, first_line_len + parseInt(result_len, 10) + crlf_len + end_indicator_len + crlf_len]        


### PR DESCRIPTION
I have a problem getting cached data if it contains the string "END". I have fixed the problem by replacing .indexOf('END') with .lastIndexOf('END') as suggested in https://github.com/elbart/node-memcache/issues/22
