### PR TITLE
handle_get() to truncate data on last "\nEND\n"

### DIFF
--- a/lib/memcache.js
+++ b/lib/memcache.js
@@ -275,8 +275,8 @@ Client.prototype.handle_get = function(buffer) {
         return [result_value, end_indicator_len + crlf_len];
     } else if (buffer.indexOf('VALUE') == 0 && buffer.indexOf('END') != -1) {
         first_line_len = buffer.indexOf(crlf) + crlf_len;
-        var end_indicator_start = buffer.indexOf('END');
-        result_len = end_indicator_start - first_line_len - crlf_len;
+        var end_indicator_start = buffer.lastIndexOf(crlf + 'END' + crlf);
+        result_len = end_indicator_start - first_line_len;
         result_value = buffer.substr(first_line_len, result_len);
         return [result_value, first_line_len + parseInt(result_len, 10) + crlf_len + end_indicator_len + crlf_len]
     } else {

--- a/lib/memcache.js
+++ b/lib/memcache.js
@@ -271,9 +271,10 @@ Client.prototype.handle_get = function(buffer) {
     var end_indicator_len = 3;
     var result_len = 0;
 
-    if (buffer.indexOf('END') == 0) {
+    if (buffer.indexOf('END' + crlf) == 0) {
         return [result_value, end_indicator_len + crlf_len];
-    } else if (buffer.indexOf('VALUE') == 0 && buffer.indexOf('END') != -1) {
+    } else if (buffer.indexOf('VALUE') == 0 
+    	&& buffer.indexOf(crlf + 'END' + crlf) != -1) {
         first_line_len = buffer.indexOf(crlf) + crlf_len;
         var end_indicator_start = buffer.lastIndexOf(crlf + 'END' + crlf);
         result_len = end_indicator_start - first_line_len;


### PR DESCRIPTION
Searching the buffer string for "END" causes problems if the data inside contains the substring "END". For example, if I retrieve the string "Please do not EXTEND beyond the edge" from my memcached server, the "END" in EXTEND will signal the end of the data, and only "Please do Not E" will be returned. This is fixed by looking for `crlf + "END" + crlf`. On the off chance that the data contains that string, it is advisable to search for the last occurrence of it, instead of the first.

From what I can tell, there is no way to retrieve multiple values with a single get request, so looking for the last instance of `crlf + "END" + crlf` should be fine. However, if I am misinterpreting, and the code needs to be able to handle multiple VALUE...END pieces, let me know and I will change lastIndexOf() to indexOf()
