### PR TITLE
Fixed version assertion

### DIFF
--- a/test/test-memcache.js
+++ b/test/test-memcache.js
@@ -193,8 +193,7 @@ mc.addHandler(function() {
 
 		mc.version(function(error, success){
 			n++;
-			assert.equal(error, null);
-			assert.length(success, 5);
+			assert.equal(true, !! success.match(/^[0-9\.]+$/));
 		});
 
 		beforeExit(function(){


### PR DESCRIPTION
`assert.length` is not/no longer a function. Also, the version may not be five characters - my local install happens to be a six-character `1.4.20`. I replaced the version test with a simple regex test to see if the response looks like a correct version number.

With this change, it passes:
![puush](http://puu.sh/btizM/917f06b204.png)
